### PR TITLE
fix: correct command for installing steiger

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This approach avoids cache invalidation issues and performs comparably to Skaffo
 ## Installation
 
 ```bash
-cargo install steiger
+cargo install steiger --git https://github.com/brainhivenl/steiger.git
 ```
 
 Or build from source:


### PR DESCRIPTION
- As steiger isnt on crates.io we should install it using the git flag