### PR TITLE
Implement deploy and run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,21 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,17 +239,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "change-case"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb9b85fd173fbe43d17902c970f23e5feda453526f4b28dbb4d2e688dffb92c"
-dependencies = [
- "fancy-regex",
- "lazy_static",
- "regex",
-]
 
 [[package]]
 name = "chrono"
@@ -622,16 +596,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91abf6555234338687bb47913978d275539235fcb77ba9863b779090b42b14"
-dependencies = [
- "bit-set",
- "regex",
 ]
 
 [[package]]
@@ -3224,11 +3188,11 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "async-tempfile",
- "change-case",
  "clap",
  "docker_credential",
  "futures",
  "gix",
+ "heck",
  "hex",
  "k8s-openapi",
  "kube",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +254,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "change-case"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb9b85fd173fbe43d17902c970f23e5feda453526f4b28dbb4d2e688dffb92c"
+dependencies = [
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "chrono"
@@ -596,6 +622,16 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae91abf6555234338687bb47913978d275539235fcb77ba9863b779090b42b14"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -3188,6 +3224,7 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "async-tempfile",
+ "change-case",
  "clap",
  "docker_credential",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2024"
 [dependencies]
 aho-corasick = "1.1.3"
 async-tempfile = "0.7.0"
-change-case = "0.2.0"
 clap = { version = "4.5.45", features = ["derive"] }
 docker_credential = "1.3.2"
 futures = "0.3.31"
 gix = { version = "0.73.0", default-features = false, features = ["status"] }
+heck = "0.5.0"
 hex = "0.4.3"
 k8s-openapi = { version = "0.25.0", features = ["v1_30"] }
 kube = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 aho-corasick = "1.1.3"
 async-tempfile = "0.7.0"
+change-case = "0.2.0"
 clap = { version = "4.5.45", features = ["derive"] }
 docker_credential = "1.3.2"
 futures = "0.3.31"

--- a/src/builder/bazel.rs
+++ b/src/builder/bazel.rs
@@ -83,12 +83,12 @@ impl Builder for BazelBuilder {
 
     async fn build(
         self,
-        mut progress: prodash::tree::Item,
         Context {
             service_name,
             platform,
-            input,
-        }: Context<Self::Input>,
+            mut progress,
+        }: Context,
+        input: Self::Input,
     ) -> Result<Output, Self::Error> {
         progress.set_name(&service_name);
         progress.message(MessageLevel::Info, "starting builder");

--- a/src/builder/bazel.rs
+++ b/src/builder/bazel.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, process::ExitStatus};
 
 use miette::Diagnostic;
-use prodash::messages::MessageLevel;
 use tokio::process::Command;
 
 use crate::{
@@ -91,14 +90,14 @@ impl Builder for BazelBuilder {
         input: Self::Input,
     ) -> Result<Output, Self::Error> {
         progress.set_name(&service_name);
-        progress.message(MessageLevel::Info, "starting builder");
+        progress.info("starting builder");
 
         let mut root_cmd = Command::new(&self.binary);
         let mut cmd = root_cmd.arg("build");
 
         if let Some(platform) = input.platforms.get(&platform) {
             cmd = cmd.arg(format!("--platforms={platform}"));
-            progress.message(MessageLevel::Info, format!("using platform: {platform}"));
+            progress.info(format!("using platform: {platform}"));
         }
 
         let status = exec::run_with_progress(
@@ -108,19 +107,16 @@ impl Builder for BazelBuilder {
         .await?;
 
         if !status.success() {
-            progress.message(
-                MessageLevel::Failure,
-                format!(
-                    "build failed with exit code: {}",
-                    status.code().unwrap_or_default()
-                ),
-            );
+            progress.fail(format!(
+                "build failed with exit code: {}",
+                status.code().unwrap_or_default()
+            ));
 
             return Err(BazelError::Build(status));
         }
 
-        progress.message(MessageLevel::Success, "build finished".to_string());
-        progress.message(MessageLevel::Info, "gathering output".to_string());
+        progress.done("build finished".to_string());
+        progress.info("gathering output".to_string());
 
         let cquery = self.get_files_output(input.targets.values()).await?;
         let mut artifacts = HashMap::default();

--- a/src/builder/ko.rs
+++ b/src/builder/ko.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, process::ExitStatus};
 
 use async_tempfile::TempDir;
-use gix::progress::MessageLevel;
 use miette::Diagnostic;
 use tokio::process::Command;
 
@@ -54,7 +53,7 @@ impl Builder for KoBuilder {
         input: Self::Input,
     ) -> Result<Output, Self::Error> {
         progress.set_name(&service_name);
-        progress.message(MessageLevel::Info, "starting builder");
+        progress.info("starting builder");
 
         let dest = TempDir::new_with_name(&service_name).await?;
         let status = exec::run_with_progress(
@@ -71,18 +70,15 @@ impl Builder for KoBuilder {
         .await?;
 
         if !status.success() {
-            progress.message(
-                MessageLevel::Failure,
-                format!(
-                    "build failed with exit code: {}",
-                    status.code().unwrap_or_default()
-                ),
-            );
+            progress.fail(format!(
+                "build failed with exit code: {}",
+                status.code().unwrap_or_default()
+            ));
 
             return Err(KoError::Build(status));
         }
 
-        progress.message(MessageLevel::Success, "build finished".to_string());
+        progress.done("build finished".to_string());
 
         let images = image::load_from_path(dest).await?;
 

--- a/src/builder/ko.rs
+++ b/src/builder/ko.rs
@@ -3,7 +3,6 @@ use std::{path::PathBuf, process::ExitStatus};
 use async_tempfile::TempDir;
 use gix::progress::MessageLevel;
 use miette::Diagnostic;
-use prodash::tree::Item;
 use tokio::process::Command;
 
 use crate::{
@@ -47,12 +46,12 @@ impl Builder for KoBuilder {
 
     async fn build(
         self,
-        mut progress: Item,
         Context {
             service_name,
             platform,
-            input,
-        }: Context<Self::Input>,
+            mut progress,
+        }: Context,
+        input: Self::Input,
     ) -> Result<Output, Self::Error> {
         progress.set_name(&service_name);
         progress.message(MessageLevel::Info, "starting builder");

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,5 +1,5 @@
 use miette::Diagnostic;
-use prodash::{messages::MessageLevel, tree::Item};
+use prodash::tree::Item;
 use tokio::{task::JoinSet, time::Instant};
 
 use crate::{
@@ -117,7 +117,7 @@ impl MetaBuild {
         let mut set = JoinSet::default();
 
         pb.init(Some(self.config.build.len()), None);
-        pb.message(MessageLevel::Info, format!("detected platform: {platform}"));
+        pb.info(format!("detected platform: {platform}"));
 
         for (name, build) in self.config.build {
             let progress = pb.add_child(&name);
@@ -148,10 +148,7 @@ impl MetaBuild {
 
         let elapsed = instant.elapsed();
 
-        pb.message(
-            MessageLevel::Success,
-            format!("build completed in {elapsed:?}"),
-        );
+        pb.done(format!("build completed in {elapsed:?}"));
 
         Ok(output)
     }

--- a/src/builder/nix.rs
+++ b/src/builder/nix.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf, process::ExitStatus, sync::Arc};
 use aho_corasick::AhoCorasick;
 use miette::Diagnostic;
 use once_cell::sync::Lazy;
-use prodash::{Progress, messages::MessageLevel, tree::Item};
+use prodash::{Progress, tree::Item};
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
 use tokio::{
@@ -166,7 +166,7 @@ impl EvalResult {
         mut progress: Item,
     ) -> Result<OutPaths, NixError> {
         if let Some(error) = self.error.take() {
-            progress.message(MessageLevel::Failure, &error);
+            progress.fail(error.clone());
             return Err(NixError::Eval(error));
         }
 
@@ -248,7 +248,7 @@ impl NixBuilder {
             .arg("--flake")
             .arg(format!(".#packages.{system}"));
 
-        progress.message(MessageLevel::Info, format!("using platform: {system}"));
+        progress.info(format!("using platform: {system}"));
 
         let child = exec::spawn(cmd).await?;
         progress::proxy_stdio(child.stderr, progress.add_child("nix").into());

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -1,0 +1,52 @@
+use std::{path::Path, sync::Arc};
+
+use miette::Diagnostic;
+
+use crate::{
+    cmd::build::output::Output,
+    config::Config,
+    deploy::{DeployError, MetaDeployer, helm::HelmError},
+    progress,
+};
+
+#[derive(Debug, Diagnostic, thiserror::Error)]
+pub enum InputError {
+    #[error("failed to read file")]
+    IO(#[from] std::io::Error),
+    #[error("failed to parse input file")]
+    Serde(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Diagnostic, thiserror::Error)]
+pub enum Error {
+    #[error("failed to read input file")]
+    #[diagnostic(transparent)]
+    Input(#[from] InputError),
+    #[error("failed to deploy")]
+    #[diagnostic(transparent)]
+    Deploy(#[from] DeployError),
+    #[error("failed to init helm deployer")]
+    #[diagnostic(transparent)]
+    Helm(#[from] HelmError),
+}
+
+async fn read_input(path: impl AsRef<Path>) -> Result<Output, InputError> {
+    let content = tokio::fs::read(path).await?;
+    Ok(serde_json::from_slice(&content)?)
+}
+
+pub async fn run(config: Config, input_file: &Path) -> Result<(), Error> {
+    let input = read_input(input_file).await?;
+    let root = progress::tree();
+    let handle = progress::setup_line_renderer(&root);
+    let progress = root.add_child("deploy");
+
+    let mut deploy = MetaDeployer::new(config, Arc::new(input));
+
+    deploy.validate(&progress).await?;
+    deploy.deploy(progress).await?;
+
+    handle.shutdown_and_wait();
+
+    Ok(())
+}

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -39,11 +39,11 @@ pub async fn run(config: Config, input_file: &Path) -> Result<(), Error> {
     let input = read_input(input_file).await?;
     let root = progress::tree();
     let handle = progress::setup_line_renderer(&root);
-    let progress = root.add_child("deploy");
+    let mut progress = root.add_child("deploy");
 
     let mut deploy = MetaDeployer::new(config, Arc::new(input));
 
-    deploy.validate(&progress).await?;
+    deploy.validate(&mut progress).await?;
     deploy.deploy(progress).await?;
 
     handle.shutdown_and_wait();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,1 +1,2 @@
 pub mod build;
+pub mod deploy;

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,10 +8,14 @@ use miette::Diagnostic;
 use serde::Deserialize;
 use serde_yml::{Mapping, Value};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
+    #[serde(default)]
+    pub insecure_registries: Vec<String>,
     pub build: HashMap<String, Build>,
+    #[serde(default)]
+    pub deploy: HashMap<String, Release>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -45,13 +49,31 @@ pub struct Nix {
     pub flake: Option<PathBuf>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum Build {
     Ko(Ko),
     Bazel(Bazel),
     Docker(Docker),
     Nix(Nix),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Helm {
+    pub path: String,
+    pub namespace: Option<String>,
+    pub timeout: Option<String>,
+    #[serde(default)]
+    pub values: HashMap<String, String>,
+    #[serde(default)]
+    pub values_files: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum Release {
+    Helm(Helm),
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/deploy/helm.rs
+++ b/src/deploy/helm.rs
@@ -1,0 +1,131 @@
+use std::{path::PathBuf, process::ExitStatus};
+
+use gix::progress::MessageLevel;
+use miette::Diagnostic;
+use prodash::tree::Item;
+
+use crate::{
+    config::Helm,
+    deploy::{Context, Deployer},
+    exec::{self, CmdBuilder},
+};
+
+#[derive(Debug, Diagnostic, thiserror::Error)]
+pub enum HelmError {
+    #[error("failed to find helm binary")]
+    Path(#[from] which::Error),
+    #[error("failed to locate helm chart")]
+    Chart(#[from] std::io::Error),
+    #[error("helm chart at '{0}' is not a directory")]
+    NotADir(String),
+    #[error("failed to run 'helm upgrade': {0}")]
+    Install(ExitStatus),
+}
+
+#[derive(Clone)]
+pub struct HelmDeployer {
+    binary: PathBuf,
+}
+
+impl HelmDeployer {
+    async fn upgrade(
+        &mut self,
+        progress: &mut Item,
+        release: &str,
+        ctx: &Context<Helm>,
+    ) -> Result<(), HelmError> {
+        progress.message(
+            MessageLevel::Info,
+            "upgrade/install helm release".to_string(),
+        );
+
+        let mut cmd = CmdBuilder::new(&self.binary);
+
+        for build in ctx.output.builds.iter() {
+            cmd.flag(
+                "--set",
+                format!(
+                    "steiger.{}.image={}",
+                    change_case::camel_case(&build.image_name),
+                    build.tag
+                ),
+            );
+        }
+
+        if let Some(timeout) = &ctx.input.timeout {
+            cmd.flag("--timeout", timeout);
+        }
+
+        if let Some(namespace) = &ctx.input.namespace {
+            cmd.flag("--namespace", namespace);
+        }
+
+        for (key, value) in &ctx.input.values {
+            cmd.flag("--set", format!("{key}={value}"));
+        }
+
+        for file in &ctx.input.values_files {
+            cmd.flag("--values", file);
+        }
+
+        let status = exec::run_with_progress(
+            cmd.arg("upgrade")
+                .arg("--install")
+                .arg(release)
+                .arg(&ctx.input.path),
+            progress.add_child(format!("{release} › helm")),
+        )
+        .await?;
+
+        if !status.success() {
+            progress.message(
+                MessageLevel::Failure,
+                format!(
+                    "deployment failed with exit code: {}",
+                    status.code().unwrap_or_default()
+                ),
+            );
+
+            return Err(HelmError::Install(status));
+        }
+
+        Ok(())
+    }
+}
+
+impl Deployer for HelmDeployer {
+    type Error = HelmError;
+    type Input = Helm;
+
+    fn try_init() -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        which::which("helm")
+            .map(|binary| Self { binary })
+            .map_err(|e| e.into())
+    }
+
+    async fn validate(&self, input: &Self::Input) -> Result<(), Self::Error> {
+        let meta = tokio::fs::metadata(&input.path).await?;
+
+        if !meta.is_dir() {
+            return Err(HelmError::NotADir(input.path.clone()));
+        }
+
+        Ok(())
+    }
+
+    async fn deploy(
+        mut self,
+        mut progress: Item,
+        release: String,
+        ctx: Context<Self::Input>,
+    ) -> Result<(), Self::Error> {
+        self.upgrade(&mut progress, &release, &ctx).await?;
+
+        progress.message(MessageLevel::Success, "deployment finished".to_string());
+
+        Ok(())
+    }
+}

--- a/src/deploy/helm.rs
+++ b/src/deploy/helm.rs
@@ -1,6 +1,5 @@
 use std::{path::PathBuf, process::ExitStatus};
 
-use gix::progress::MessageLevel;
 use miette::Diagnostic;
 use prodash::tree::Item;
 
@@ -34,10 +33,7 @@ impl HelmDeployer {
         release: &str,
         ctx: &Context<Helm>,
     ) -> Result<(), HelmError> {
-        progress.message(
-            MessageLevel::Info,
-            "upgrade/install helm release".to_string(),
-        );
+        progress.info("upgrade/install helm release");
 
         let mut cmd = CmdBuilder::new(&self.binary);
 
@@ -78,13 +74,10 @@ impl HelmDeployer {
         .await?;
 
         if !status.success() {
-            progress.message(
-                MessageLevel::Failure,
-                format!(
-                    "deployment failed with exit code: {}",
-                    status.code().unwrap_or_default()
-                ),
-            );
+            progress.fail(format!(
+                "deployment failed with exit code: {}",
+                status.code().unwrap_or_default()
+            ));
 
             return Err(HelmError::Install(status));
         }
@@ -124,7 +117,7 @@ impl Deployer for HelmDeployer {
     ) -> Result<(), Self::Error> {
         self.upgrade(&mut progress, &release, &ctx).await?;
 
-        progress.message(MessageLevel::Success, "deployment finished".to_string());
+        progress.done("deployment finished".to_string());
 
         Ok(())
     }

--- a/src/deploy/helm.rs
+++ b/src/deploy/helm.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, process::ExitStatus};
 
+use heck::ToLowerCamelCase;
 use miette::Diagnostic;
 use prodash::tree::Item;
 
@@ -42,7 +43,7 @@ impl HelmDeployer {
                 "--set",
                 format!(
                     "steiger.{}.image={}",
-                    change_case::camel_case(&build.image_name),
+                    build.image_name.to_lower_camel_case(),
                     build.tag
                 ),
             );

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+
+use futures::TryFutureExt;
+use gix::progress::MessageLevel;
+use miette::Diagnostic;
+use prodash::tree::Item;
+use tokio::{task::JoinSet, time::Instant};
+
+use crate::{
+    cmd::build::output::Output,
+    config::{Config, Release},
+    deploy::helm::HelmDeployer,
+};
+
+pub mod helm;
+
+pub struct Context<T> {
+    pub input: T,
+    pub output: Arc<Output>,
+}
+
+impl<T> Context<T> {
+    pub fn new(input: T, output: Arc<Output>) -> Self {
+        Self { input, output }
+    }
+}
+
+pub trait Deployer: Clone {
+    type Error;
+    type Input;
+
+    fn try_init() -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+    async fn validate(&self, input: &Self::Input) -> Result<(), Self::Error>;
+    async fn deploy(
+        self,
+        progress: Item,
+        release: String,
+        input: Context<Self::Input>,
+    ) -> Result<(), Self::Error>;
+}
+
+type ErrorOf<T> = <T as Deployer>::Error;
+
+#[derive(Debug, Diagnostic, thiserror::Error)]
+#[error("one or more deployments failed")]
+pub struct MultiError {
+    #[related]
+    pub errors: Vec<DeployError>,
+}
+
+#[derive(Debug, Diagnostic, thiserror::Error)]
+pub enum DeployError {
+    #[error("helm error")]
+    #[diagnostic(transparent)]
+    Helm(#[from] ErrorOf<HelmDeployer>),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Multi(MultiError),
+}
+
+fn ensure<T: Deployer>(deploy: &Option<T>) -> T {
+    match deploy {
+        Some(deploy) => deploy.clone(),
+        None => unreachable!(),
+    }
+}
+
+pub struct MetaDeployer {
+    config: Config,
+    output: Arc<Output>,
+    helm: Option<HelmDeployer>,
+}
+
+impl MetaDeployer {
+    pub fn new(config: Config, output: Arc<Output>) -> Self {
+        Self {
+            config,
+            output,
+            helm: None,
+        }
+    }
+
+    pub async fn validate(&mut self, pb: &Item) -> Result<(), DeployError> {
+        pb.message(MessageLevel::Info, "validating releases");
+
+        for release in self.config.deploy.values() {
+            match release {
+                Release::Helm(helm) => {
+                    if self.helm.is_none() {
+                        self.helm = Some(HelmDeployer::try_init()?)
+                    }
+
+                    ensure(&self.helm).validate(helm).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn deploy(self, mut pb: Item) -> Result<(), DeployError> {
+        let instant = Instant::now();
+        let mut set = JoinSet::<Result<_, DeployError>>::new();
+
+        pb.init(Some(self.config.deploy.len()), None);
+        pb.message(MessageLevel::Info, "starting deployment");
+
+        for (name, release) in self.config.deploy {
+            let progress = pb.add_child(&name);
+
+            match release {
+                Release::Helm(helm) => {
+                    set.spawn(
+                        ensure(&self.helm)
+                            .deploy(progress, name, Context::new(helm, Arc::clone(&self.output)))
+                            .map_err(DeployError::Helm),
+                    );
+                }
+            }
+        }
+
+        let mut errors = vec![];
+
+        while let Some(Ok(result)) = set.join_next().await {
+            pb.inc();
+
+            if let Err(e) = result {
+                pb.message(MessageLevel::Failure, "deployment failed");
+                errors.push(e);
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(DeployError::Multi(MultiError { errors }));
+        }
+
+        let elapsed = instant.elapsed();
+
+        pb.message(
+            MessageLevel::Success,
+            format!("deployment completed in {elapsed:?}"),
+        );
+
+        Ok(())
+    }
+}

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,4 +1,6 @@
 use std::{
+    ffi::OsStr,
+    ops::{Deref, DerefMut},
     process::{ExitStatus, Stdio},
     sync::Arc,
 };
@@ -11,6 +13,54 @@ use tokio::{
 };
 
 use crate::progress;
+
+pub struct CmdBuilder(Command);
+
+pub trait AsArg {
+    fn as_arg(&self) -> impl AsRef<OsStr>;
+}
+
+impl AsArg for &str {
+    fn as_arg(&self) -> impl AsRef<OsStr> {
+        self
+    }
+}
+
+impl AsArg for &String {
+    fn as_arg(&self) -> impl AsRef<OsStr> {
+        self
+    }
+}
+
+impl AsArg for String {
+    fn as_arg(&self) -> impl AsRef<OsStr> {
+        self
+    }
+}
+
+impl CmdBuilder {
+    pub fn new<S: AsRef<OsStr>>(cmd: S) -> Self {
+        Self(Command::new(cmd))
+    }
+
+    pub fn flag(&mut self, arg1: impl AsArg, arg2: impl AsArg) {
+        self.0.arg(arg1.as_arg()).arg(arg2.as_arg());
+    }
+}
+
+impl Deref for CmdBuilder {
+    type Target = Command;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for CmdBuilder {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 pub struct ChildWithStdio {
     pub inner: Child,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,34 +30,48 @@ struct Opts {
 
 #[derive(Parser)]
 enum Cmd {
+    /// Build an OCI image.
     Build {
-        #[arg(short, long, help = "OCI registry to use")]
+        /// OCI registry to use.
+        #[arg(short, long)]
         repo: Option<String>,
 
-        #[arg(short, long, help = "Output file location")]
+        /// Output file location.
+        #[arg(short, long)]
         output_file: Option<PathBuf>,
 
-        #[arg(long, help = "Platform selector (e.g. linux/amd64)")]
+        /// Platform selector (e.g. linux/amd64).
+        #[arg(long)]
         platform: Option<String>,
 
-        #[arg(short, long, help = "Profile name")]
+        /// Profile name.
+        #[arg(short, long)]
         profile: Option<String>,
     },
+
+    /// Deploy an OCI image.
     Deploy {
-        #[arg(short, long, help = "Input file location")]
+        /// Input file location.
+        #[arg(short, long)]
         input_file: PathBuf,
 
-        #[arg(short, long, help = "Profile name")]
+        /// Profile name.
+        #[arg(short, long)]
         profile: Option<String>,
     },
+
+    /// Run an OCI image.
     Run {
-        #[arg(short, long, help = "OCI registry to use")]
+        /// OCI registry to use.
+        #[arg(short, long)]
         repo: String,
 
-        #[arg(long, help = "Platform selector (e.g. linux/amd64)")]
+        /// Platform selector (e.g. linux/amd64).
+        #[arg(long)]
         platform: Option<String>,
 
-        #[arg(short, long, help = "Profile name")]
+        /// Profile name.
+        #[arg(short, long)]
         profile: Option<String>,
     },
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use prodash::{
     Progress,
-    messages::MessageLevel,
     render::line::JoinHandle,
     tree::{Root, root::Options},
 };
@@ -41,7 +40,7 @@ where
 
     tokio::spawn(async move {
         while let Ok(Some(line)) = lines.next_line().await {
-            progress.message(MessageLevel::Info, line);
+            progress.info(line);
         }
     });
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -7,7 +7,7 @@ use oci_client::{
     errors::{OciDistributionError, OciErrorCode},
     secrets::RegistryAuth,
 };
-use prodash::{messages::MessageLevel, tree::Item};
+use prodash::tree::Item;
 
 use crate::image::Image;
 
@@ -74,7 +74,7 @@ impl Registry {
 
     pub async fn push(
         &mut self,
-        progress: Item,
+        mut progress: Item,
         image_ref: &Reference,
         image: Image,
     ) -> Result<Option<PushResponse>, PushError> {
@@ -84,13 +84,13 @@ impl Registry {
         if let Some(digest) = self.try_resolve_digest(&self.auth, image_ref).await? {
             // If the digest matches the image's digest, we can skip pushing
             if digest == image.digest {
-                progress.message(MessageLevel::Info, "image already exists, skipping push");
+                progress.info("image already exists, skipping push");
                 return Ok(None);
             }
         }
 
         progress.init(Some(image.layers.len()), None);
-        progress.message(MessageLevel::Info, "pushing image");
+        progress.info("pushing image");
 
         // Push blobs with cache
         stream::iter(&image.layers)
@@ -134,7 +134,7 @@ impl Registry {
             .push_manifest(image_ref, &image.manifest.into())
             .await?;
 
-        progress.message(MessageLevel::Success, "image pushed");
+        progress.done("image pushed");
 
         Ok(Some(PushResponse {
             config_url,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,8 +1,9 @@
+use docker_credential::{CredentialRetrievalError, DockerCredential};
 use futures::{StreamExt, TryStreamExt, future, stream};
 use miette::Diagnostic;
 use oci_client::{
     Client, Reference,
-    client::PushResponse,
+    client::{ClientConfig, ClientProtocol, PushResponse},
     errors::{OciDistributionError, OciErrorCode},
     secrets::RegistryAuth,
 };
@@ -16,26 +17,50 @@ pub enum PushError {
     Oci(#[from] OciDistributionError),
 }
 
+fn parse_host(repo: &str) -> &str {
+    repo.split('/').next().unwrap_or_default()
+}
+
+pub fn load_credentials(repo: &str) -> Result<RegistryAuth, CredentialRetrievalError> {
+    match docker_credential::get_credential(parse_host(repo)) {
+        Ok(DockerCredential::IdentityToken(_)) => unimplemented!(),
+        Ok(DockerCredential::UsernamePassword(user, pass)) => Ok(RegistryAuth::Basic(user, pass)),
+        Err(
+            CredentialRetrievalError::HelperFailure { .. }
+            | CredentialRetrievalError::ConfigNotFound
+            | CredentialRetrievalError::NoCredentialConfigured,
+        ) => Ok(RegistryAuth::Anonymous),
+        Err(e) => Err(e),
+    }
+}
+
 #[derive(Clone)]
 pub struct Registry {
-    auth: RegistryAuth,
     client: Client,
+    auth: RegistryAuth,
 }
 
 impl Registry {
-    pub fn new(client: Client, auth: RegistryAuth) -> Self {
-        Self { auth, client }
+    pub fn with_config(auth: RegistryAuth, insecure_registies: &[String]) -> Self {
+        let config = ClientConfig {
+            protocol: ClientProtocol::HttpsExcept(
+                [insecure_registies, &["localhost".to_string()]].concat(),
+            ),
+            ..ClientConfig::default()
+        };
+
+        Self {
+            client: Client::new(config),
+            auth,
+        }
     }
 
     async fn try_resolve_digest(
         &self,
+        auth: &RegistryAuth,
         reference: &Reference,
     ) -> Result<Option<String>, OciDistributionError> {
-        match self
-            .client
-            .fetch_manifest_digest(reference, &self.auth)
-            .await
-        {
+        match self.client.fetch_manifest_digest(reference, auth).await {
             Ok(digest) => Ok(Some(digest)),
             // If the manifest is not found, we assume the image does not exist
             Err(OciDistributionError::ImageManifestNotFoundError(_)) => Ok(None),
@@ -53,7 +78,10 @@ impl Registry {
         image_ref: &Reference,
         image: Image,
     ) -> Result<Option<PushResponse>, PushError> {
-        if let Some(digest) = self.try_resolve_digest(image_ref).await? {
+        let registry = image_ref.resolve_registry();
+        self.client.store_auth_if_needed(registry, &self.auth).await;
+
+        if let Some(digest) = self.try_resolve_digest(&self.auth, image_ref).await? {
             // If the digest matches the image's digest, we can skip pushing
             if digest == image.digest {
                 progress.message(MessageLevel::Info, "image already exists, skipping push");
@@ -63,10 +91,6 @@ impl Registry {
 
         progress.init(Some(image.layers.len()), None);
         progress.message(MessageLevel::Info, "pushing image");
-
-        self.client
-            .store_auth_if_needed(image_ref.resolve_registry(), &self.auth)
-            .await;
 
         // Push blobs with cache
         stream::iter(&image.layers)


### PR DESCRIPTION
Implements `deploy` and `run` subcommands where `deploy` handles the deployment on Kubernetes based on the output tags file and `run` runs both `build` and `deploy`.