### PR TITLE
feat: rework nix outputs structure & improve cross-compilation support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,15 @@
         system: fun (import nixpkgs {inherit system;})
       );
   in {
+    lib = {
+      defaultSystems = ["aarch64-darwin" "x86_64-darwin" "x86_64-linux" "aarch64-linux"];
+
+      eachCrossSystem = systems: packages:
+        nixpkgs.lib.genAttrs systems (localSystem:
+          nixpkgs.lib.genAttrs systems (crossSystem:
+            packages localSystem crossSystem));
+    };
+
     packages = forEachSystem (
       pkgs: let
         craneLib = crane.mkLib pkgs;

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,11 +49,26 @@ pub struct Ko {
     pub import_path: Option<String>,
 }
 
+#[derive(Clone, Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum PlatformStrategy {
+    #[default]
+    Native,
+    CrossSystem,
+}
+
+fn default_flake_path() -> PathBuf {
+    PathBuf::from(".")
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Nix {
     pub packages: HashMap<String, String>,
-    pub flake: Option<PathBuf>,
+    #[serde(default = "default_flake_path")]
+    pub flake: PathBuf,
+    #[serde(default)]
+    pub platform_strategy: PlatformStrategy,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/tests/nix/flake.nix
+++ b/tests/nix/flake.nix
@@ -13,7 +13,7 @@
     overlays = [steiger.overlays.ociTools];
     pkgs = import nixpkgs { inherit system overlays; };
   in {
-    packages.${system} = {
+    steigerImages.${system} = {
       default = pkgs.ociTools.buildImage {
         name = "hello";
 


### PR DESCRIPTION
In order to cross-compile with nix often you need to build the host platform's package where you can then configure cross-compilation. I've added a new config option to support this use-case