### PR TITLE
feat: add optional use_monolithic_push entry to steiger config

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, mem, path::Path};
 use docker_credential::CredentialRetrievalError;
 use miette::Diagnostic;
 use oci_client::Reference;
-use tokio::{fs, task::JoinSet, time::Instant};
 use steiger::git;
+use tokio::{fs, task::JoinSet, time::Instant};
 
 use crate::{
     build::{
@@ -89,6 +89,7 @@ pub async fn run(
     let root = progress::tree();
     let handle = progress::setup_line_renderer(&root);
     let insecure_registries = mem::take(&mut config.insecure_registries);
+    let use_monolithic_push = config.use_monolithic_push;
 
     let (tag, default_repo) = (config.tag_format.clone(), config.default_repo.take());
     let events = EventsClient::from_env();
@@ -119,7 +120,7 @@ pub async fn run(
     progress.init(Some(output.artifacts.len()), None);
 
     let auth = registry::load_credentials(&repo)?;
-    let registry = Registry::with_config(auth, &insecure_registries);
+    let registry = Registry::with_config(auth, &insecure_registries, use_monolithic_push);
     let mut artifacts = HashMap::new();
     let mut set = JoinSet::<Result<_, PushError>>::new();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct Config {
     pub default_repo: Option<String>,
     #[serde(default)]
     pub tag_format: String,
+    #[serde(default)]
+    pub use_monolithic_push: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -39,20 +39,27 @@ pub fn load_credentials(repo: &str) -> Result<RegistryAuth, CredentialRetrievalE
 #[derive(Clone)]
 pub struct Registry {
     client: Client,
+    use_monolithic_push: bool,
     auth: RegistryAuth,
 }
 
 impl Registry {
-    pub fn with_config(auth: RegistryAuth, insecure_registies: &[String]) -> Self {
+    pub fn with_config(
+        auth: RegistryAuth,
+        insecure_registies: &[String],
+        use_monolithic_push: bool,
+    ) -> Self {
         let config = ClientConfig {
             protocol: ClientProtocol::HttpsExcept(
                 [insecure_registies, &["localhost".to_string()]].concat(),
             ),
+            use_monolithic_push,
             ..ClientConfig::default()
         };
 
         Self {
             client: Client::new(config),
+            use_monolithic_push,
             auth,
         }
     }
@@ -91,6 +98,29 @@ impl Registry {
             }
         }
 
+        if self.use_monolithic_push {
+            progress.init(None, None);
+            progress.info("pushing image");
+
+            let image_urls = self
+                .client
+                .push(
+                    image_ref,
+                    &image.layers,
+                    image.config,
+                    &self.auth,
+                    image.manifest.into(),
+                )
+                .await?;
+
+            progress.done("image pushed");
+
+            return Ok(Some(PushResponse {
+                config_url: image_urls.config_url,
+                manifest_url: image_urls.manifest_url,
+            }));
+        }
+
         progress.init(Some(image.layers.len()), None);
         progress.info("pushing image");
 
@@ -118,10 +148,12 @@ impl Registry {
                                 // Retry on digest mismatch (400) and invalid range (416) errors.
                                 // Root cause unknown; we should probably look into this but retry is safe for now.
                                 // Retrying on 5xx server errors is also acceptable.
-                                Err(e @ OciDistributionError::ServerError {
-                                    code: 400 | 416 | 500..599,
-                                    ..
-                                }) => {
+                                Err(
+                                    e @ OciDistributionError::ServerError {
+                                        code: 400 | 416 | 500..599,
+                                        ..
+                                    },
+                                ) => {
                                     last_err = Some(e);
                                     tokio::time::sleep(Duration::from_secs(i * 2)).await;
                                 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -81,46 +81,40 @@ impl Registry {
         }
     }
 
-    pub async fn push(
+    async fn monolithic_push(
         &mut self,
         mut progress: Item,
         image_ref: &Reference,
         image: Image,
     ) -> Result<Option<PushResponse>, PushError> {
-        let registry = image_ref.resolve_registry();
-        self.client.store_auth_if_needed(registry, &self.auth).await;
+        progress.init(None, None);
+        progress.info("pushing image");
 
-        if let Some(digest) = self.try_resolve_digest(&self.auth, image_ref).await? {
-            // If the digest matches the image's digest, we can skip pushing
-            if digest == image.digest {
-                progress.info("image already exists, skipping push");
-                return Ok(None);
-            }
-        }
+        let image_urls = self
+            .client
+            .push(
+                image_ref,
+                &image.layers,
+                image.config,
+                &self.auth,
+                image.manifest.into(),
+            )
+            .await?;
 
-        if self.use_monolithic_push {
-            progress.init(None, None);
-            progress.info("pushing image");
+        progress.done("image pushed");
 
-            let image_urls = self
-                .client
-                .push(
-                    image_ref,
-                    &image.layers,
-                    image.config,
-                    &self.auth,
-                    image.manifest.into(),
-                )
-                .await?;
+        Ok(Some(PushResponse {
+            config_url: image_urls.config_url,
+            manifest_url: image_urls.manifest_url,
+        }))
+    }
 
-            progress.done("image pushed");
-
-            return Ok(Some(PushResponse {
-                config_url: image_urls.config_url,
-                manifest_url: image_urls.manifest_url,
-            }));
-        }
-
+    async fn layered_push(
+        &mut self,
+        mut progress: Item,
+        image_ref: &Reference,
+        image: Image,
+    ) -> Result<Option<PushResponse>, PushError> {
         progress.init(Some(image.layers.len()), None);
         progress.info("pushing image");
 
@@ -191,5 +185,29 @@ impl Registry {
             config_url,
             manifest_url,
         }))
+    }
+
+    pub async fn push(
+        &mut self,
+        mut progress: Item,
+        image_ref: &Reference,
+        image: Image,
+    ) -> Result<Option<PushResponse>, PushError> {
+        let registry = image_ref.resolve_registry();
+        self.client.store_auth_if_needed(registry, &self.auth).await;
+
+        if let Some(digest) = self.try_resolve_digest(&self.auth, image_ref).await? {
+            // If the digest matches the image's digest, we can skip pushing
+            if digest == image.digest {
+                progress.info("image already exists, skipping push");
+                return Ok(None);
+            }
+        }
+
+        if self.use_monolithic_push {
+            return self.monolithic_push(progress, image_ref, image).await;
+        }
+
+        self.layered_push(progress, image_ref, image).await
     }
 }


### PR DESCRIPTION
When using steiger normally with Google's Artifact Registry, the normal layered push will fail with a method 405 not allowed.

This PR introduces a new config option `useMonolithicPush` which will use oci-client's `push` instead of the normal layered push to circumvent the issue.